### PR TITLE
Fix player placement and add route/block selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Football-playbook
+# Football Playbook
+
+Simple web application to design football plays. Click **Add player** to place a player on the field, then click the player and click on the field to draw a line. Use the selector to choose a **Route** (arrow ending) or a **Block** (horizontal line ending).
+
+Open `index.html` in a browser to use the app.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Football Playbook</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="controls">
+    <button id="addPlayer">Add player</button>
+    <select id="lineType">
+      <option value="route">Route</option>
+      <option value="block">Block</option>
+    </select>
+  </div>
+  <canvas id="field" width="800" height="400"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,121 @@
+const canvas = document.getElementById('field');
+const ctx = canvas.getContext('2d');
+const addBtn = document.getElementById('addPlayer');
+const lineTypeSelect = document.getElementById('lineType');
+
+const players = [];
+let selectedPlayer = null;
+
+class Player {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+    this.routes = [];
+  }
+
+  draw() {
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, 10, 0, Math.PI * 2);
+    ctx.fillStyle = 'white';
+    ctx.fill();
+    ctx.strokeStyle = 'black';
+    ctx.stroke();
+
+    this.routes.forEach(r => drawLine(this.x, this.y, r.x, r.y, r.type));
+  }
+}
+
+function drawField() {
+  ctx.fillStyle = '#2e7d32';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = 'white';
+  ctx.lineWidth = 2;
+  const step = canvas.width / 12;
+  for (let i = 0; i <= 12; i++) {
+    const x = i * step;
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, canvas.height);
+    ctx.stroke();
+  }
+
+  ctx.beginPath();
+  ctx.moveTo(0, canvas.height / 2);
+  ctx.lineTo(canvas.width, canvas.height / 2);
+  ctx.stroke();
+}
+
+function redraw() {
+  drawField();
+  players.forEach(p => p.draw());
+}
+
+addBtn.addEventListener('click', () => {
+  const p = new Player(canvas.width / 2, canvas.height / 2);
+  players.push(p);
+  redraw();
+});
+
+canvas.addEventListener('click', e => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+
+  const hit = players.find(p => Math.hypot(p.x - x, p.y - y) < 10);
+  if (hit) {
+    selectedPlayer = hit;
+    return;
+  }
+
+  if (selectedPlayer) {
+    selectedPlayer.routes.push({ x, y, type: lineTypeSelect.value });
+    selectedPlayer = null;
+    redraw();
+  }
+});
+
+function drawLine(x1, y1, x2, y2, type) {
+  ctx.strokeStyle = 'yellow';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+
+  if (type === 'route') {
+    drawArrow(x1, y1, x2, y2);
+  } else {
+    drawBlock(x1, y1, x2, y2);
+  }
+}
+
+function drawArrow(x1, y1, x2, y2) {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const len = 10;
+  ctx.beginPath();
+  ctx.moveTo(x2, y2);
+  ctx.lineTo(
+    x2 - len * Math.cos(angle - Math.PI / 6),
+    y2 - len * Math.sin(angle - Math.PI / 6)
+  );
+  ctx.moveTo(x2, y2);
+  ctx.lineTo(
+    x2 - len * Math.cos(angle + Math.PI / 6),
+    y2 - len * Math.sin(angle + Math.PI / 6)
+  );
+  ctx.stroke();
+}
+
+function drawBlock(x1, y1, x2, y2) {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const len = 10;
+  const bx = x2 - len * Math.sin(angle);
+  const by = y2 + len * Math.cos(angle);
+  ctx.beginPath();
+  ctx.moveTo(x2, y2);
+  ctx.lineTo(bx, by);
+  ctx.stroke();
+}
+
+redraw();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,15 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+}
+
+#controls {
+  margin-bottom: 10px;
+}
+
+#field {
+  border: 1px solid #ccc;
+  background-color: #2e7d32;
+  display: block;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- Show football field with yard lines and add player button functionality
- Enable drawing selectable routes or blocks, ending with arrow or horizontal line
- Document usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6890762149f4832f852af2aa17c01a11