### PR TITLE
Add football playbook creator with local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Football Playbook
 
-Simple web application to design football plays. Click **Add player** to place a player on the field, then click the player and click on the field to draw a line. Use the selector to choose a **Route** (arrow ending) or a **Block** (horizontal line ending).
+Simple web application to design American football plays.
+
+## Features
+
+* Add offensive and defensive players by selecting a position and placing them on the field.
+* Drag players to adjust their alignment.
+* Toggle **Rita route** mode to click out route points for the selected player.
+* Give the play a name and save it to your browser's `localStorage`.
+* Load any saved play from the list and continue editing.
 
 Open `index.html` in a browser to use the app.
+

--- a/index.html
+++ b/index.html
@@ -2,18 +2,31 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Football Playbook</title>
+  <title>Football Playbook Creator</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div id="controls">
-    <button id="addPlayer">Add player</button>
-    <select id="lineType">
-      <option value="route">Route</option>
-      <option value="block">Block</option>
+    <input type="text" id="playName" placeholder="Spelnamn" />
+    <select id="roleSelect">
+      <option value="QB">QB</option>
+      <option value="RB">RB</option>
+      <option value="WR">WR</option>
+      <option value="TE">TE</option>
+      <option value="OL">OL</option>
+      <option value="DL">DL</option>
+      <option value="LB">LB</option>
+      <option value="CB">CB</option>
+      <option value="S">S</option>
     </select>
+    <button id="addPlayer">Lägg till spelare</button>
+    <button id="routeMode">Rita route</button>
+    <button id="savePlay">Spara spel</button>
+    <button id="loadPlay">Ladda spel</button>
   </div>
-  <canvas id="field" width="800" height="400"></canvas>
+  <ul id="playList"></ul>
+  <canvas id="field" width="960" height="480"></canvas>
   <script src="script.js"></script>
 </body>
 </html>
+

--- a/style.css
+++ b/style.css
@@ -1,15 +1,50 @@
 body {
   font-family: sans-serif;
+  background-color: #f4f4f4;
   text-align: center;
 }
 
 #controls {
-  margin-bottom: 10px;
+  margin: 10px auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+button,
+select,
+input {
+  padding: 5px 8px;
+}
+
+button.active {
+  background-color: #ffd700;
+}
+
+#playList {
+  list-style: none;
+  padding: 0;
+  margin: 10px auto;
+  max-width: 300px;
+  text-align: left;
+}
+
+#playList li {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  background: #fff;
+  margin-bottom: 4px;
+  cursor: pointer;
+}
+
+#playList li:hover {
+  background: #eee;
 }
 
 #field {
-  border: 1px solid #ccc;
-  background-color: #ffffff;
+  border: 2px solid #333;
+  background-color: #0B6623;
   display: block;
   margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- Design Football Playbook Creator interface with play naming, position picker and canvas field
- Implement draggable players, route drawing mode and localStorage save/load
- Style controls, field and play list for a basic playbook UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907ce32a6c832fa99b8ba4ce38b8c3